### PR TITLE
ci(release): add workflow permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,11 @@
 name: Release
 
+# Add these permission settings
+permissions:
+  contents: write      # Required for creating releases
+  pull-requests: write # Required for creating release PRs
+  issues: write       # Required for creating release notes
+
 on:
   push:
     branches: [ main ]
@@ -8,34 +14,34 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: "!contains(github.event.head_commit.message, 'chore(release)')"
-    
+
     steps:
     - uses: actions/checkout@v4
       with:
         fetch-depth: 0
         token: ${{ secrets.GITHUB_TOKEN }}
-        
+
     - name: Python Semantic Release
       uses: python-semantic-release/python-semantic-release@v8.7.2
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
-        
+
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
         python-version: "3.11"
-        
+
     - name: Install Poetry
       uses: snok/install-poetry@v1
       with:
         version: 1.8.5
-        
+
     - name: Update version
       run: |
         git config --global user.name "github-actions"
         git config --global user.email "github-actions@github.com"
         poetry run cz bump --yes
-        
+
     - name: Create Release
       uses: softprops/action-gh-release@v1
       if: steps.tag_version.outputs.tag
@@ -44,4 +50,4 @@ jobs:
       with:
         tag_name: ${{ steps.tag_version.outputs.tag }}
         name: Release ${{ steps.tag_version.outputs.tag }}
-        body: ${{ steps.tag_version.outputs.changelog }} 
+        body: ${{ steps.tag_version.outputs.changelog }}


### PR DESCRIPTION
# Why:
- Fix release workflow permissions
- Enable automated version bumping
- Allow GitHub Actions to create releases

# What:
- Added write permissions for contents
- Added write permissions for pull-requests
- Added write permissions for issues
- Maintained semantic release configuration