### PR TITLE
fix(release): install commitizen in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,6 +36,10 @@ jobs:
       with:
         version: 1.8.5
 
+    - name: Install dependencies
+      run: |
+        poetry install --with dev  # Install dev dependencies which include commitizen
+
     - name: Update version
       run: |
         git config --global user.name "github-actions"


### PR DESCRIPTION
# Why:
- Fix release workflow failure
- Enable automated version bumping
- Ensure all required tools are available

# What:
- Added dependency installation step
- Included dev dependencies in Poetry install
- Maintained existing release configuration